### PR TITLE
login test example using behave + splinter

### DIFF
--- a/func_tests/features/environment.py
+++ b/func_tests/features/environment.py
@@ -1,0 +1,22 @@
+from splinter.browser import Browser
+
+def before_all(context):
+    browser = context.config.userdata.get('browser')
+    if browser is not None:
+        context.browser = Browser(browser)
+    else:
+        context.browser = Browser('firefox')
+    context.base_url = context.config.userdata.get("base_url")
+    context.admin_username = context.config.userdata.get("username")
+    context.admin_password = context.config.userdata.get("password")
+
+def after_all(context):
+    context.browser.quit()
+    context.browser = None
+
+def after_step(context, step):
+    if step.status == "failed":
+        # -- ENTER DEBUGGER: Zoom in on failure location.
+        # NOTE: Use IPython debugger, same for pdb (basic python debugger).
+        import ipdb
+        ipdb.post_mortem(step.exc_traceback)

--- a/func_tests/features/login.feature
+++ b/func_tests/features/login.feature
@@ -1,0 +1,14 @@
+Feature: testing admin login
+  Scenario: visting the admin site redirects to login
+    Given we visit the admin site
+     then we are redirected to the login page
+
+  Scenario: successful login
+    Given we are on the login page
+     when we provide correct credentials
+     then we see the recordings page
+
+  Scenario: failed login
+    Given we are on the login page
+     when we provide incorrect credentials
+     then we see a login error

--- a/func_tests/features/steps/login.py
+++ b/func_tests/features/steps/login.py
@@ -1,0 +1,33 @@
+from behave import given, when, then
+from hamcrest import *
+from mh_selenium.pages import LoginPage
+
+@given('we visit the admin site')
+def impl(context):
+    context.browser.visit(context.base_url + '/admin')
+
+@given('we are on the login page')
+def impl(context):
+    context.browser.visit(context.base_url + '/login.html')
+
+@then('we are redirected to the login page')
+def impl(context):
+    assert_that(context.browser.title, contains_string('Login Page'))
+
+@when('we provide correct credentials')
+def impl(context):
+    page = LoginPage(context.browser.driver)
+    page.login(context.admin_username, context.admin_password)
+
+@then('we see the recordings page')
+def impl(context):
+    assert_that(context.browser.url, ends_with('#/recordings'))
+
+@when('we provide incorrect credentials')
+def impl(context):
+    page = LoginPage(context.browser.driver)
+    page.login('foo', 'bar')
+
+@then('we see a login error')
+def impl(context):
+    assert_that(context.browser.url, ends_with('login.html?error'))

--- a/func_tests/run.py
+++ b/func_tests/run.py
@@ -1,0 +1,7 @@
+
+import sys
+
+from behave.__main__ import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ click==5.1
 fabric==1.10.2
 pytimeparse==1.1.5
 unipath==1.1
+behave==1.2.5
+splinter==0.7.3
+PyHamcrest==1.8.5


### PR DESCRIPTION
### do not merge

Example that tests a successful login and a failed login.

Command to run: 
`behave -D base_url=http://<host> -D username=<admin user> -D password=<admin passwd> func_tests/features`

Output:

```
Feature: testing admin login # features/login.feature:1

  Scenario: visting the admin site redirects to login  # features/login.feature:2
    Given we visit the admin site                      # features/steps/login.py:5
    Then we are redirected to the login page           # features/steps/login.py:13

  Scenario: successful login            # features/login.feature:6
    Given we are on the login page      # features/steps/login.py:9
    When we provide correct credentials # features/steps/login.py:17
    Then we see the recordings page     # features/steps/login.py:22

  Scenario: failed login                  # features/login.feature:11
    Given we are on the login page        # features/steps/login.py:9
    When we provide incorrect credentials # features/steps/login.py:26
    Then we see a login error             # features/steps/login.py:31

1 feature passed, 0 failed, 0 skipped
3 scenarios passed, 0 failed, 0 skipped
8 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m2.060s

Process finished with exit code 0
```
