### PR TITLE
Changes to allow ghost inspector test execution from mh-opsworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Current command tree:
     * `mh inbox put`
     * `mh inbox symlink`
     * `mh series create`
-    * `mh upload`
-    * `mh trim`
+    * `mh rec upload`
+    * `mh rec trim`
     * `mh gi list`
     * `mh gi exec`
     
@@ -148,14 +148,43 @@ uploads for files > 1G.
 
 ### Ghost Inspector test commands
 
-Preliminary support for executing Ghost Inspector tests is provided via the 
-`mh gi` command group. Options for these commands are simply passed along to
-the `py.test` subprocess, so for now take a gander at the [pytest-ghostinspector](https://github.com/harvard-dce/pytest-ghostinspector)
-docs to see what those options should be.
+Support for executing Ghost Inspector tests is provided via the 
+`mh gi` command group. Options for these commands are translated and passed
+along to `py.test` which uses the `pytest-ghostinspector` plugin to execute
+or list the available tests.
 
 #### gi list
+
+    Usage: mh gi list [OPTIONS]
+    
+      Collect and list available tests
+    
+    Options:
+      --key TEXT    ghost inspector API key
+      --suite TEXT  ID of a ghost inspector suite
+      --test TEXT   ID of a ghost inspector test
+      --help        Show this message and exit.
+
  
 #### gi exec
+
+    Usage: mh gi exec [OPTIONS]
+    
+      Execute tests
+    
+    Options:
+      --runners INTEGER  num tests to run concurrently [default: 4]
+      --var TEXT         extra test variable(s); repeatable
+      --key TEXT         ghost inspector API key
+      --suite TEXT       ID of a ghost inspector suite
+      --test TEXT        ID of a ghost inspector test
+      --help             Show this message and exit.
+
+
+#### Integration with mh-opsworks
+
+Ghost Inspector tests can be executed in the context of your [`mh-opsworks`](http://github.com/harvard-dce/mh-opsworks).
+See the `README.ui-testing.md` doc in that repo for details.
 
 ### Specifying an alternate driver: `-D, --driver` option
 
@@ -163,33 +192,7 @@ The default browser driver, and the one used 98% during development of these tas
 Hopefully not necessary to change this, but if you find a task executing unreliably it might
 be worth trying, `--driver=chrome`. You'll need to have [chromedriver](https://sites.google.com/a/chromium.org/chromedriver/) installed.
 
-
-## Config file for common options
-
-When run the `mh` command will look for a config file at `~/.mh-ui-testing`, and
-create it if it does not exist.
-
-Example:
-
-    [mh]
-    username = 
-    password = 
-    host = ec2-12-34-56-78.compute-1.amazonaws.com
-    driver = firefox
-    inbox_path = /var/matterhorn/inbox
-    
-    [pytest]
-    testpaths = gi_tests
-    addopts = 
-
-If you grow weary of typing all the `-u` and `-H` options for every command you can
-set the values in this file by editing manually or by running, e.g.:
-
-`mh config -H my.mh.hostname.com -u user -p mypass`
-
-which will update `~/.mh-ui-testing` for you.
-
-## Example process
+## Examples
 
 The following sequence of commands provides an example of how to upload a set of video files
 to the Matterhorn inbox, create symlinks to populate the inbox selection menu

--- a/mh_cli/__init__.py
+++ b/mh_cli/__init__.py
@@ -1,21 +1,18 @@
-__version__ = '0.9.4'
+__version__ = '1.0.0'
 
+import os
 import click
 click.disable_unicode_literals_warning = True
 
-from mh_cli.common import ClickState, config_options, pass_state
+from mh_cli.common import ClickState, pass_state
 
 @click.group()
+@click.option('--working-dir', help='change to this dir before executing cmds')
 @click.pass_context
-def cli(ctx):
+def cli(ctx, working_dir):
     ctx.ensure_object(ClickState)
-
-@cli.command()
-@config_options
-@pass_state
-def config(state):
-    """Save typing by setting common options in a config file"""
-    state.save_config()
+    if working_dir is not None:
+        os.chdir(working_dir)
 
 from gi import gi
 from inbox import inbox

--- a/mh_cli/__init__.py
+++ b/mh_cli/__init__.py
@@ -1,10 +1,11 @@
-__version__ = '1.0.0'
-
 import os
 import click
+from mh_cli.common import ClickState, pass_state
+
 click.disable_unicode_literals_warning = True
 
-from mh_cli.common import ClickState, pass_state
+__version__ = '1.0.0'
+
 
 @click.group()
 @click.option('--working-dir', help='change to this dir before executing cmds')

--- a/mh_cli/common.py
+++ b/mh_cli/common.py
@@ -22,42 +22,7 @@ class ClickState(object):
         self.ssh_user = None
         self.driver = 'firefox'
         self.inbox_path = '/var/matterhorn/inbox'
-        self.conf_file = os.path.join(os.path.expanduser('~'), '.mh-ui-testing')
-        self.load_config()
-
-    def load_config(self):
-        self.config = ConfigParser.ConfigParser()
-
-        if os.path.isfile(self.conf_file):
-            self.config.read(self.conf_file)
-            if self.config.has_section('mh'):
-                # load settings into envvars to be picked up by click options
-                for k, v in self.config.items('mh'):
-                    varname = 'MHUIT_%s' % k.upper()
-                    # not if empty or already set
-                    if v and varname not in os.environ:
-                        os.environ[varname] = v
-        else:
-            self.config.add_section('mh')
-            self.config.add_section('pytest')
-            self.config.set('pytest', 'testpaths', 'gi_tests')
-            self.config.set('pytest', 'addopts', '')
-            with open(self.conf_file, 'wb') as fh:
-                self.config.write(fh)
-
-    def save_config(self):
-        for opt in [
-            'username',
-            'password',
-            'host',
-            'driver',
-            'inbox_path',
-            'ssh_user'
-        ]:
-            if hasattr(self, opt) and getattr(self, opt) is not None:
-                self.config.set('mh', opt, getattr(self, opt))
-        with open(self.conf_file, 'wb') as fh:
-            self.config.write(fh)
+        self.working_dir = None
 
     @property
     def base_url(self):
@@ -135,15 +100,6 @@ def selenium_options(f):
 
 def inbox_options(f):
     f = host_option(f)
-    f = user_option(f)
-    f = inbox_path_option(f)
-    return f
-
-def config_options(f):
-    f = password_option(f, required=False)
-    f = username_option(f, required=False)
-    f = host_option(f, required=False)
-    f = driver_option(f)
     f = user_option(f)
     f = inbox_path_option(f)
     return f

--- a/mh_cli/common.py
+++ b/mh_cli/common.py
@@ -1,5 +1,3 @@
-import ConfigParser
-import os
 import click
 import socket
 
@@ -30,9 +28,12 @@ class ClickState(object):
 
     @property
     def inbox_dest(self):
-        return Path(self.inbox_path).parent.child('files','collection','inbox')
+        return Path(self.inbox_path) \
+            .parent.child('files', 'collection', 'inbox')
+
 
 pass_state = click.make_pass_decorator(ClickState, ensure=True)
+
 
 def state_callback(ctx, option, value):
     state = ctx.ensure_object(ClickState)
@@ -46,21 +47,24 @@ def host_callback(ctx, option, value):
         setattr(state, 'host', socket.gethostbyaddr(value)[0])
     return value
 
+
 def password_option(f, required=True):
-    return click.option('-p','--password',
+    return click.option('-p', '--password',
                         expose_value=False,
                         required=required,
                         help='MH admin login password',
                         envvar='MHUIT_PASSWORD',
                         callback=state_callback)(f)
 
+
 def username_option(f, required=True):
-    return click.option('-u','--username',
+    return click.option('-u', '--username',
                         expose_value=False,
                         required=required,
                         help='MH admin login username',
                         envvar='MHUIT_USERNAME',
                         callback=state_callback)(f)
+
 
 def user_option(f):
     return click.option('--ssh_user',
@@ -69,13 +73,15 @@ def user_option(f):
                         envvar='MHUIT_SSH_USER',
                         callback=state_callback)(f)
 
+
 def host_option(f, required=True):
-    return click.option('-H','--host',
+    return click.option('-H', '--host',
                         expose_value=False,
                         required=required,
                         help='host/ip of remote admin node',
                         envvar='MHUIT_HOST',
                         callback=host_callback)(f)
+
 
 def driver_option(f):
     return click.option('-D', '--driver',
@@ -84,12 +90,14 @@ def driver_option(f):
                         envvar='MHUIT_DRIVER',
                         callback=state_callback)(f)
 
+
 def inbox_path_option(f):
     return click.option('-I', '--inbox_path',
                         expose_value=False,
                         help='alternate path to recording inbox',
                         envvar='MHUIT_INBOX_PATH',
                         callback=state_callback)(f)
+
 
 def selenium_options(f):
     f = password_option(f)
@@ -98,11 +106,13 @@ def selenium_options(f):
     f = driver_option(f)
     return f
 
+
 def inbox_options(f):
     f = host_option(f)
     f = user_option(f)
     f = inbox_path_option(f)
     return f
+
 
 def init_fabric(click_cmd):
     @wraps(click_cmd)
@@ -114,10 +124,12 @@ def init_fabric(click_cmd):
             env.user = state.ssh_user
 
         if not remote_exists(state.inbox_path):
-            raise UsageError("Invalid remote inbox path: %s" % state.inbox_path)
+            raise UsageError(
+                "Invalid remote inbox path: %s" % state.inbox_path)
 
         return click_cmd(state, *args, **kwargs)
     return wrapped
+
 
 def init_browser(init_path=''):
     def decorator(click_cmd):
@@ -133,7 +145,8 @@ def init_browser(init_path=''):
                     with page.wait_for_page_change():
                         page.login(state.username, state.password)
                         if 'Login' in state.browser.title:
-                            raise RuntimeError("Login failed. Check your user/pass.")
+                            raise RuntimeError(
+                                "Login failed. Check your user/pass.")
                     state.browser.visit(urljoin(state.base_url, init_path))
 
                 result = click_cmd(state, *args, **kwargs)
@@ -143,4 +156,3 @@ def init_browser(init_path=''):
 
         return _wrapped_cmd
     return decorator
-

--- a/mh_cli/gi.py
+++ b/mh_cli/gi.py
@@ -1,9 +1,10 @@
 import click
 from mh_cli import cli
-from mh_cli.common import pass_state, host_option, state_callback
+from mh_cli.common import pass_state, state_callback
 
 from fabric.api import local, settings, hide
 from multiprocessing import cpu_count
+
 
 def test_option(f):
     return click.option('--test',
@@ -12,12 +13,14 @@ def test_option(f):
                         multiple=True,
                         callback=state_callback)(f)
 
+
 def suite_option(f):
     return click.option('--suite',
                         expose_value=False,
                         help='ID of a ghost inspector suite',
                         multiple=True,
                         callback=state_callback)(f)
+
 
 def key_option(f):
     return click.option('--key',
@@ -26,6 +29,7 @@ def key_option(f):
                         envvar='GI_API_KEY',
                         callback=state_callback)(f)
 
+
 def var_option(f):
     return click.option('--var',
                         expose_value=False,
@@ -33,12 +37,15 @@ def var_option(f):
                         multiple=True,
                         callback=state_callback)(f)
 
+
 def runners_option(f):
     return click.option('--runners',
                         expose_value=False,
-                        help='num tests to run concurrently [default: %d]' % (cpu_count() / 2),
+                        help='num tests to run concurrently [default: %d]'
+                             % (cpu_count() / 2),
                         default=cpu_count() / 2,
                         callback=state_callback)(f)
+
 
 def gi_list_options(f):
     f = test_option(f)
@@ -46,15 +53,18 @@ def gi_list_options(f):
     f = key_option(f)
     return f
 
+
 def gi_exec_options(f):
     f = gi_list_options(f)
     f = var_option(f)
     f = runners_option(f)
     return f
 
+
 @cli.group()
 def gi():
     """Do stuff with Ghost Inspector tests"""
+
 
 @gi.command(name='list')
 @gi_list_options
@@ -67,6 +77,7 @@ def gi_list(state):
     if state.suite:
         params.extend('--gi_suite %s' % x for x in state.suite)
     _pytest_cmd('py.test --collect-only ' + ' '.join(params))
+
 
 @gi.command(name='exec')
 @gi_exec_options
@@ -84,6 +95,7 @@ def gi_exec(state):
     if state.var:
         params.extend('--gi_param %s' % x for x in state.var)
     _pytest_cmd('py.test ' + ' '.join(params))
+
 
 def _pytest_cmd(cmd):
     with settings(

--- a/mh_cli/gi.py
+++ b/mh_cli/gi.py
@@ -1,29 +1,93 @@
 import click
 from mh_cli import cli
-from mh_cli.common import pass_state
+from mh_cli.common import pass_state, host_option, state_callback
 
-from os.path import dirname
-from fabric.api import local, lcd
+from fabric.api import local, settings, hide
+from multiprocessing import cpu_count
+
+def test_option(f):
+    return click.option('--test',
+                        expose_value=False,
+                        help='ID of a ghost inspector test',
+                        multiple=True,
+                        callback=state_callback)(f)
+
+def suite_option(f):
+    return click.option('--suite',
+                        expose_value=False,
+                        help='ID of a ghost inspector suite',
+                        multiple=True,
+                        callback=state_callback)(f)
+
+def key_option(f):
+    return click.option('--key',
+                        expose_value=False,
+                        help='ghost inspector API key',
+                        envvar='GI_API_KEY',
+                        callback=state_callback)(f)
+
+def var_option(f):
+    return click.option('--var',
+                        expose_value=False,
+                        help='extra test variable(s); repeatable',
+                        multiple=True,
+                        callback=state_callback)(f)
+
+def runners_option(f):
+    return click.option('--runners',
+                        expose_value=False,
+                        help='num tests to run concurrently [default: %d]' % (cpu_count() / 2),
+                        default=cpu_count() / 2,
+                        callback=state_callback)(f)
+
+def gi_list_options(f):
+    f = test_option(f)
+    f = suite_option(f)
+    f = key_option(f)
+    return f
+
+def gi_exec_options(f):
+    f = gi_list_options(f)
+    f = var_option(f)
+    f = runners_option(f)
+    return f
 
 @cli.group()
 def gi():
     """Do stuff with Ghost Inspector tests"""
 
-@gi.command(name='list', context_settings=dict(ignore_unknown_options=True))
-@click.argument('gi_args', nargs=-1, type=click.UNPROCESSED)
+@gi.command(name='list')
+@gi_list_options
 @pass_state
-def gi_list(state, gi_args):
+def gi_list(state):
     """Collect and list available tests"""
-    cmd = "py.test -c %s --verbose --collect-only %s" % (state.conf_file, " ".join(gi_args))
-    with(lcd(dirname(dirname(__file__)))):
-        local(cmd)
+    params = ['--gi_key %s' % state.key]
+    if state.test:
+        params.extend('--gi_test %s' % x for x in state.test)
+    if state.suite:
+        params.extend('--gi_suite %s' % x for x in state.suite)
+    _pytest_cmd('py.test --collect-only ' + ' '.join(params))
 
-
-@gi.command(name='exec', context_settings=dict(ignore_unknown_options=True))
-@click.argument('gi_args', nargs=-1, type=click.UNPROCESSED)
+@gi.command(name='exec')
+@gi_exec_options
 @pass_state
-def gi_exec(state, gi_args):
+def gi_exec(state):
     """Execute tests"""
-    cmd = "py.test -c %s --verbose %s" % (state.conf_file, " ".join(gi_args))
-    with(lcd(dirname(dirname(__file__)))):
+    params = [
+        '--gi_key %s' % state.key,
+        '-n %d' % state.runners
+    ]
+    if state.test:
+        params.extend('--gi_test %s' % x for x in state.test)
+    if state.suite:
+        params.extend('--gi_suite %s' % x for x in state.suite)
+    if state.var:
+        params.extend('--gi_param %s' % x for x in state.var)
+    _pytest_cmd('py.test ' + ' '.join(params))
+
+def _pytest_cmd(cmd):
+    with settings(
+            hide('warnings'),
+            hide('running'),
+            warn_only=True):
         local(cmd)

--- a/mh_cli/inbox.py
+++ b/mh_cli/inbox.py
@@ -10,9 +10,11 @@ from fabric.operations import put
 from fabric.colors import cyan
 from fabric.contrib.files import exists as remote_exists
 
+
 @cli.group()
 def inbox():
     """Manipulate the MH recording file inbox"""
+
 
 @inbox.command(name='put')
 @click.option('-f', '--file')
@@ -28,12 +30,14 @@ def inbox_put(state, file):
     elif exists(file):
         size_in_bytes = getsize(file)
         if size_in_bytes / (1024 * 1024) > 1024:
-            raise UsageError("File > 1G. Upload to s3 and use the url instead.")
+            raise UsageError(
+                "File > 1G. Upload to s3 and use the url instead.")
         result = put(local_path=file,
                      remote_path=state.inbox_path, use_sudo=True)
     else:
         raise UsageError("Local file %s not found" % file)
     print(cyan("Files created: {}".format(str(result))))
+
 
 @inbox.command(name='symlink')
 @click.option('-f', '--file')
@@ -52,6 +56,7 @@ def inbox_symlink(state, file, count):
             link = remote_path.stem + '_' + str(i + 1) + remote_path.ext
             sudo("ln -sf {} {}".format(remote_path, link))
         return
+
 
 @inbox.command(name='list')
 @click.argument('match', default='')

--- a/mh_cli/rec.py
+++ b/mh_cli/rec.py
@@ -10,23 +10,34 @@ from mh_pages.pages import RecordingsPage, \
     TrimPage, \
     UploadPage
 
+
 @cli.group()
 def rec():
     """Do stuff with Matterhorn recordings"""
 
+
 @rec.command()
-@click.option('--presenter', help="Presenter video")
-@click.option('--presentation', help="Presentation video")
-@click.option('--combined', help="Combined presenter/presentation video")
-@click.option('--series', help="Series title. Should match an existing series.")
-@click.option('--title', default='mh-ui-testing upload', help="Recording title")
-@click.option('--type', default='L01', help="Recording type")
-@click.option('-i', '--inbox', is_flag=True, help="Use a MH inbox media file")
-@click.option('--live_stream', is_flag=True, help="Flag to indicate a live stream recording")
+@click.option('--presenter',
+              help="Presenter video")
+@click.option('--presentation',
+              help="Presentation video")
+@click.option('--combined',
+              help="Combined presenter/presentation video")
+@click.option('--series',
+              help="Series title. Should match an existing series.")
+@click.option('--title', default='mh-ui-testing upload',
+              help="Recording title")
+@click.option('--type', default='L01',
+              help="Recording type")
+@click.option('-i', '--inbox', is_flag=True,
+              help="Use a MH inbox media file")
+@click.option('--live_stream', is_flag=True,
+              help="Flag to indicate a live stream recording")
 @selenium_options
 @pass_state
 @init_browser('/admin')
-def upload(state, presenter, presentation, combined, series, title, type, inbox, live_stream):
+def upload(state, presenter, presentation, combined,
+           series, title, type, inbox, live_stream):
     """Upload a recording from a local path or the inbox"""
 
     page = RecordingsPage(state.browser)
@@ -59,6 +70,7 @@ def upload(state, presenter, presentation, combined, series, title, type, inbox,
 
     page.upload_button.click()
     page.wait_for_upload_finish()
+
 
 @rec.command()
 @click.option('-f', '--filter')
@@ -93,7 +105,7 @@ def trim(state, filter=None, count=None):
             # the same thing > once (e.g. the entry doesn't get removed from
             # the table because the workflow hasn't actually resumed)
             link = page.trim_links[link_idx]
-        except (TimeoutException,IndexError):
+        except (TimeoutException, IndexError):
             break
 
         href = link['href']
@@ -112,4 +124,3 @@ def trim(state, filter=None, count=None):
             count -= 1
             if count == 0:
                 break
-

--- a/mh_cli/series.py
+++ b/mh_cli/series.py
@@ -11,7 +11,8 @@ from mh_pages.pages import ApiDocPage
 CATALOG_XML = '''
 <?xml version="1.0" encoding="UTF-8"?>
 <dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/"
-    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oc="http://www.opencastproject.org/matterhorn/">
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:oc="http://www.opencastproject.org/matterhorn/">
     <dcterms:creator>Harvard Extension School</dcterms:creator>
     <dcterms:contributor>Henry H. Leitner</dcterms:contributor>
     <dcterms:description>http://extension.harvard.edu</dcterms:description>
@@ -55,22 +56,24 @@ ACL_XML = '''
 </acl>
 '''
 
+
 @cli.group()
 def series():
     """Do stuff with Matterhorn series"""
 
+
 @series.command()
 @selenium_options
-@click.option('--title', default='Test Offering', help="Title of the series")
+@click.option('--title', default='Test Offering',
+              help="Title of the series")
 @click.option('--subject', default=None,
-              help="Subject of the series. " \
-                + "If not specified this will take the form 'TEST S-xxxxx', " \
-                + "where 'xxxxx' is the last 5 digits of the identifier."
-              )
+              help=("Subject of the series. If not specified this "
+                    "will take the form 'TEST S-xxxxx', "
+                    "where 'xxxxx' is the last 5 digits of the identifier."))
 @click.option('--id', default=None,
-              help="Series identifier. If not specified " \
-                 + "this will be generated for you in the format '203501xxxxx' " \
-                 + "where 'xxxxx' is a random number sequence")
+              help=("Series identifier. If not specified this will be "
+                    "generated for you in the format '203501xxxxx' "
+                    "where 'xxxxx' is a random number sequence"))
 @pass_state
 @init_browser('/admin')
 def create(state, title, subject, id):

--- a/mh_pages/pages/__init__.py
+++ b/mh_pages/pages/__init__.py
@@ -1,2 +1,1 @@
-
 from page import *

--- a/mh_pages/pages/locators.py
+++ b/mh_pages/pages/locators.py
@@ -1,13 +1,15 @@
-
 from selenium.webdriver.common.by import By
+
 
 class LoginLocators(object):
     USERNAME_INPUT = (By.NAME, 'j_username')
     PASSWORD_INPUT = (By.NAME, 'j_password')
     SUBMIT_BUTTON = (By.NAME, 'submit')
 
+
 class AdminLocators(object):
     RECORDINGS_TAB = (By.CSS_SELECTOR, 'a#i18n_tab_recording')
+
 
 class RecordingsLocators(object):
     UPLOAD_RECORDING_BUTTON = (By.CSS_SELECTOR, 'button#uploadButton')
@@ -19,6 +21,7 @@ class RecordingsLocators(object):
     ON_HOLD_TAB = (By.CSS_SELECTOR, 'label[for=state-hold]')
     TRIM_LINK = (By.CSS_SELECTOR, 'a[title="Review / VideoEdit"]')
     TRIM_IFRAME = (By.CSS_SELECTOR, 'iframe#holdActionUI')
+
 
 class UploadLocators(object):
     TITLE_INPUT = (By.CSS_SELECTOR, 'input#title')
@@ -43,13 +46,17 @@ class UploadLocators(object):
 
     FILE_INPUT_IFRAME = (By.CSS_SELECTOR, 'iframe.uploadForm-container')
 
-    SINGLE_FILE_LOCAL_RADIO = (By.CSS_SELECTOR,'input#fileSourceSingleA')
+    SINGLE_FILE_LOCAL_RADIO = (By.CSS_SELECTOR, 'input#fileSourceSingleA')
     SINGLE_FILE_INBOX_RADIO = (By.CSS_SELECTOR, 'input#fileSourceSingleB')
 
-    MULTI_FILE_PRESENTATION_LOCAL_RADIO = (By.CSS_SELECTOR, 'input#fileSourcePresentationA')
-    MULTI_FILE_PRESENTATION_INBOX_RADIO = (By.CSS_SELECTOR, 'input#fileSourcePresentationB')
-    MULTI_FILE_PRESENTER_LOCAL_RADIO = (By.CSS_SELECTOR, 'input#fileSourcePresenterA')
-    MULTI_FILE_PRESENTER_INBOX_RADIO = (By.CSS_SELECTOR, 'input#fileSourcePresenterB')
+    MULTI_FILE_PRESENTATION_LOCAL_RADIO = (By.CSS_SELECTOR,
+                                           'input#fileSourcePresentationA')
+    MULTI_FILE_PRESENTATION_INBOX_RADIO = (By.CSS_SELECTOR,
+                                           'input#fileSourcePresentationB')
+    MULTI_FILE_PRESENTER_LOCAL_RADIO = (By.CSS_SELECTOR,
+                                        'input#fileSourcePresenterA')
+    MULTI_FILE_PRESENTER_INBOX_RADIO = (By.CSS_SELECTOR,
+                                        'input#fileSourcePresenterB')
 
     LOCAL_FILE_SELECTOR = (By.CSS_SELECTOR, 'input#file')
     INBOX_FILE_SELECT = (By.CSS_SELECTOR, 'select#file')
@@ -61,6 +68,7 @@ class UploadLocators(object):
     UPLOAD_BUTTON = (By.CSS_SELECTOR, 'button#submitButton')
     UPLOAD_PROGRESS_DIALOG = (By.CSS_SELECTOR, 'div#progressStage')
 
+
 class TrimLocators(object):
     SHORTCUT_TABLE = (By.CSS_SELECTOR, 'div#rightBox')
     CLIP_BEGIN_INPUT = (By.CSS_SELECTOR, 'span#clipBegin > input')
@@ -69,4 +77,3 @@ class TrimLocators(object):
     CLIP_REMOVE_BUTTON = (By.CSS_SELECTOR, 'a#splitRemover-0')
     CONTINUE_BUTTON = (By.CSS_SELECTOR, 'input#continueButton')
     CLEAR_BUTTON = (By.CSS_SELECTOR, 'input#clearList')
-

--- a/mh_pages/pages/page.py
+++ b/mh_pages/pages/page.py
@@ -15,6 +15,7 @@ from locators import RecordingsLocators, \
                      LoginLocators, \
                      AdminLocators
 
+
 class BasePage(object):
 
     def __init__(self, browser):
@@ -57,8 +58,8 @@ class BasePage(object):
     def wait_for_page_change(self, tag='html', timeout=10):
         old_ref = self.browser.find_by_tag(tag)._element
         yield
-        WebDriverWait(self.browser.driver, timeout).until(staleness_of(old_ref))
-
+        WebDriverWait(self.browser.driver, timeout) \
+            .until(staleness_of(old_ref))
 
 
 class ApiDocPage(BasePage):
@@ -98,11 +99,13 @@ class LoginPage(BasePage):
         self.password_input.type(password)
         self.submit.click()
 
+
 class AdminPage(BasePage):
 
     @property
     def recordings_tab(self):
         return self.get_element(AdminLocators.RECORDINGS_TAB)
+
 
 class RecordingsPage(AdminPage):
 
@@ -154,6 +157,7 @@ class RecordingsPage(AdminPage):
         throw exceptions about not being clickable at point blah, blah
         """
         self.browser.driver.execute_script("arguments[0].click();", tab_elem)
+
 
 class UploadPage(BasePage):
 
@@ -294,8 +298,8 @@ class UploadPage(BasePage):
         self.series_input.type(series)
         self.series_autocomplete_items[0].click()
 
-    def set_upload_files(self, presenter=None, presentation=None, combined=None,
-                         is_inbox=False):
+    def set_upload_files(self, presenter=None, presentation=None,
+                         combined=None, is_inbox=False):
         """
         The MH upload UI does some crazy stuff with iframes.
         None of the iframe elements have unique ids, so this
@@ -327,11 +331,14 @@ class UploadPage(BasePage):
             if is_inbox:
                 self.inbox_file_select.select_by_value(file)
             else:
-                # NOTE: this will silently fail if it's not an absolute path to an existing file
+                # NOTE: this will silently fail if it's not
+                # an absolute path to an existing file
                 self.local_file_selector.fill(abspath(file))
 
     def wait_for_upload_finish(self):
-        WebDriverWait(self.browser.driver, 1000000).until_not(visible(self.upload_progress_dialog._element))
+        WebDriverWait(self.browser.driver, 1000000) \
+            .until_not(visible(self.upload_progress_dialog._element))
+
 
 class TrimPage(BasePage):
 

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,12 @@ version = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M).g
 install_requires = [
     "selenium==2.48.0",
     "click==5.1",
-    "fabric==1.10.2",
+    "Fabric==1.11.1",
     "pytimeparse==1.1.5",
     "unipath==1.1",
     "pytest>=2.8.1",
-    "pytest-ghostinspector>=0.1.2",
+    "pytest-ghostinspector>=0.3.0",
+    "pytest-xdist==1.14",
     "splinter==0.7.3"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "pytimeparse==1.1.5",
     "unipath==1.1",
     "pytest>=2.8.1",
-    "pytest-ghostinspector>=0.3.0",
+    "pytest-ghostinspector==0.4.0",
     "pytest-xdist==1.14",
     "splinter==0.7.3"
 ]

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,15 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+
 def read(path):
     return codecs.open(os.path.join(here, path), 'r', 'utf-8').read()
 
 version_file = read('mh_cli/__init__.py')
-version = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M).group(1)
+version = re.search(
+    r"^__version__ = ['\"]([^'\"]*)['\"]",
+    version_file,
+    re.M).group(1)
 
 install_requires = [
     "selenium==2.48.0",


### PR DESCRIPTION
There's two commits here: one for the mh-opsworks integration changes and another to clean up some python syntax lint that I wanted to do as decided to move to v1.0.0 here. The 2nd commit has generated a lot of diff noise, so probably best to review the 1st commit in isolation.
